### PR TITLE
Add hall layout view

### DIFF
--- a/src/components/HallView.tsx
+++ b/src/components/HallView.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useRestaurant } from '../contexts/RestaurantContext';
+import { Table } from '../types';
+import { StaticTable } from './StaticTable';
+import { StaticWall } from './StaticWall';
+
+interface Props {
+  onTableClick: (table: Table) => void;
+}
+
+export const HallView: React.FC<Props> = ({ onTableClick }) => {
+  const { state } = useRestaurant();
+
+  return (
+    <div className="relative w-full h-[600px] border border-gray-300 bg-[linear-gradient(#e5e7eb_1px,transparent_1px),linear-gradient(90deg,#e5e7eb_1px,transparent_1px)] bg-[length:10px_10px]">
+      {state.walls.map((w) => (
+        <StaticWall key={w.id} wall={w} />
+      ))}
+      {state.tables.map((t) => (
+        <StaticTable key={t.id} table={t} onClick={onTableClick} />
+      ))}
+    </div>
+  );
+};

--- a/src/components/StaticTable.tsx
+++ b/src/components/StaticTable.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { Table } from '../types';
+
+const SIZE_PX: Record<NonNullable<Table['size']>, number> = {
+  small: 40,
+  medium: 56,
+  large: 72,
+};
+
+const STATUS_COLORS: Record<Table['status'], string> = {
+  free: 'bg-emerald-500',
+  occupied: 'bg-rose-500',
+  closed: 'bg-gray-400',
+};
+
+interface Props {
+  table: Table;
+  onClick?: (table: Table) => void;
+}
+
+export const StaticTable: React.FC<Props> = ({ table, onClick }) => {
+  const size = SIZE_PX[table.size ?? 'medium'];
+  const bgColor = STATUS_COLORS[table.status];
+
+  const [minutes, setMinutes] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (table.status !== 'occupied' || !table.startTime) {
+      setMinutes(null);
+      return;
+    }
+
+    const calc = () => {
+      const diffMs = Date.now() - new Date(table.startTime!).getTime();
+      setMinutes(Math.floor(diffMs / 60000));
+    };
+
+    calc();
+    const id = setInterval(calc, 60_000);
+    return () => clearInterval(id);
+  }, [table.status, table.startTime]);
+
+  const guestsBadge = useMemo(() => {
+    if (table.guests && table.guests > 0)
+      return (
+        <span className="absolute -bottom-2 -right-2 rounded bg-white px-1 py-0.5 text-[10px] font-medium text-gray-800 shadow">
+          {table.guests}
+        </span>
+      );
+    return null;
+  }, [table.guests]);
+
+  return (
+    <div
+      onClick={() => onClick?.(table)}
+      className={`select-none rounded-full text-white ${bgColor} cursor-pointer`}
+      style={{
+        position: 'absolute',
+        left: table.position?.x ?? 0,
+        top: table.position?.y ?? 0,
+        width: size,
+        height: size,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <span className="font-semibold leading-none">{table.number}</span>
+      {minutes !== null && (
+        <span className="absolute top-0.5 right-0.5 text-[9px] opacity-80">
+          {minutes} m
+        </span>
+      )}
+      {guestsBadge}
+    </div>
+  );
+};

--- a/src/components/StaticWall.tsx
+++ b/src/components/StaticWall.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Wall } from '../types';
+
+const DEFAULT_COLOR = '#475569';
+
+interface Props {
+  wall: Wall;
+}
+
+export const StaticWall: React.FC<Props> = ({ wall }) => {
+  const length = Math.hypot(wall.end.x - wall.start.x, wall.end.y - wall.start.y);
+  const angle = Math.atan2(wall.end.y - wall.start.y, wall.end.x - wall.start.x);
+
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    left: wall.start.x,
+    top: wall.start.y,
+    width: length,
+    height: wall.thickness,
+    transform: `rotate(${angle}rad)`,
+    transformOrigin: '0 0',
+    borderRadius: wall.thickness / 2,
+    background: wall.color ?? DEFAULT_COLOR,
+  };
+
+  return <div style={style} />;
+};

--- a/src/components/TablesView.tsx
+++ b/src/components/TablesView.tsx
@@ -4,11 +4,13 @@ import { TableCard } from './TableCard';
 import { ZoneFilter } from './ZoneFilter';
 import { OrderModal } from './OrderModal';
 import { Table } from '../types';
+import { HallView } from './HallView';
 
 export function TablesView() {
   const { state } = useRestaurant();
   const [selectedZone, setSelectedZone] = useState<string | null>(null);
   const [selectedTable, setSelectedTable] = useState<Table | null>(null);
+  const [viewMode, setViewMode] = useState<'cards' | 'layout'>('cards');
 
   const filteredTables = selectedZone
     ? state.tables.filter(table => table.zone === selectedZone)
@@ -24,18 +26,46 @@ export function TablesView() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="mb-8">
         <h2 className="text-2xl font-bold text-gray-900 mb-4">Управление столами</h2>
-        <ZoneFilter selectedZone={selectedZone} onZoneChange={setSelectedZone} />
+        <div className="flex items-center justify-between flex-wrap gap-4">
+          <ZoneFilter selectedZone={selectedZone} onZoneChange={setSelectedZone} />
+          <div className="flex gap-2">
+            <button
+              onClick={() => setViewMode('cards')}
+              className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
+                viewMode === 'cards'
+                  ? 'bg-gray-800 text-white'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+              }`}
+            >
+              Карточки
+            </button>
+            <button
+              onClick={() => setViewMode('layout')}
+              className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
+                viewMode === 'layout'
+                  ? 'bg-gray-800 text-white'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+              }`}
+            >
+              План зала
+            </button>
+          </div>
+        </div>
       </div>
 
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-        {filteredTables.map((table) => (
-          <TableCard
-            key={table.id}
-            table={table}
-            onTableClick={handleTableClick}
-          />
-        ))}
-      </div>
+      {viewMode === 'cards' ? (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
+          {filteredTables.map((table) => (
+            <TableCard
+              key={table.id}
+              table={table}
+              onTableClick={handleTableClick}
+            />
+          ))}
+        </div>
+      ) : (
+        <HallView onTableClick={handleTableClick} />
+      )}
 
       {selectedTable && (
         <OrderModal


### PR DESCRIPTION
## Summary
- add HallView with walls and tables on a grid
- implement StaticTable and StaticWall for read-only rendering
- allow waiters to switch between card grid and hall layout views

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e2066689c832391a8414e0b5a1dda