### PR TITLE
Optimize hall designer performance

### DIFF
--- a/src/components/DraggableTable.tsx
+++ b/src/components/DraggableTable.tsx
@@ -25,7 +25,7 @@ interface Props {
   table: Table;
 }
 
-export const DraggableTable: React.FC<Props> = ({ table }) => {
+const DraggableTableInner: React.FC<Props> = ({ table }) => {
   /* ---------------- dnd-kit ---------------- */
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({ id: table.id });
@@ -101,3 +101,5 @@ export const DraggableTable: React.FC<Props> = ({ table }) => {
     </div>
   );
 };
+
+export const DraggableTable = React.memo(DraggableTableInner);

--- a/src/components/HallDesigner.tsx
+++ b/src/components/HallDesigner.tsx
@@ -84,37 +84,54 @@ export const HallDesigner: React.FC = () => {
   );
 
   /* ---------------- Помощники для стены ---------------- */
-  const getOffset = (e: React.PointerEvent<HTMLDivElement>) => {
-    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    const raw = { x: e.clientX - rect.left, y: e.clientY - rect.top };
-    return isSnap ? { x: snap(raw.x), y: snap(raw.y) } : raw;
-  };
+  const getOffset = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      const raw = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+      return isSnap ? { x: snap(raw.x), y: snap(raw.y) } : raw;
+    },
+    [isSnap]
+  );
 
-  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (tool !== 'wall') return;
-    const start = getOffset(e);
-    setDraftWall({ id: Date.now(), start, end: start, thickness: WALL_THICKNESS });
-  };
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (tool !== 'wall') return;
+      const start = getOffset(e);
+      setDraftWall({
+        id: Date.now(),
+        start,
+        end: start,
+        thickness: WALL_THICKNESS,
+      });
+    },
+    [tool, getOffset]
+  );
 
-  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!draftWall) return;
-    setDraftWall({ ...draftWall, end: getOffset(e) });
-  };
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!draftWall) return;
+      setDraftWall({ ...draftWall, end: getOffset(e) });
+    },
+    [draftWall, getOffset]
+  );
 
-  const handlePointerUp = () => {
+  const handlePointerUp = useCallback(() => {
     if (!draftWall) return;
     // Игнорируем стены длиной < 5 px, чтобы не плодить «точки»
     const dx = draftWall.end.x - draftWall.start.x;
     const dy = draftWall.end.y - draftWall.start.y;
     if (Math.hypot(dx, dy) > 5) dispatch({ type: 'ADD_WALL', wall: draftWall });
     setDraftWall(null);
-  };
+  }, [draftWall, dispatch]);
 
   /* ---------------- UI helpers ---------------- */
-  const toolClass = (t: Tool) =>
-    `rounded px-3 py-1 text-sm shadow transition ${
-          tool === t ? 'bg-gray-800 text-white' : 'bg-white border'
-        }`;
+  const toolClass = useCallback(
+    (t: Tool) =>
+      `rounded px-3 py-1 text-sm shadow transition ${
+        tool === t ? 'bg-gray-800 text-white' : 'bg-white border'
+      }`,
+    [tool]
+  );
 
   /* ---------------- Render ---------------- */
   return (

--- a/src/components/Wall.tsx
+++ b/src/components/Wall.tsx
@@ -16,7 +16,7 @@ interface Props {
   isDraft?: boolean;
 }
 
-export const WallComponent: React.FC<Props> = ({ wall, isDraft = false }) => {
+const WallComponentInner: React.FC<Props> = ({ wall, isDraft = false }) => {
   /* ---------------- dnd-kit ---------------- */
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({ id: `wall-${wall.id}`, disabled: isDraft });
@@ -54,3 +54,5 @@ export const WallComponent: React.FC<Props> = ({ wall, isDraft = false }) => {
     />
   );
 };
+
+export const WallComponent = React.memo(WallComponentInner);


### PR DESCRIPTION
## Summary
- reduce re-renders by memoizing `DraggableTable` and `WallComponent`
- memoize handlers and helpers in `HallDesigner` to keep references stable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e226b941c8323861ec62fd6221e12